### PR TITLE
Feat/lfs to dvc

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,8 @@
     "ghcr.io/va-h/devcontainers-features/difftastic:1": {},
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
       "enableNonRootDocker": true
-    }
+    },
+    "ghcr.io/iterative/features/dvc:1": {}
   },
 
   // Configure tool-specific properties.

--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,3 @@
+/config.local
+/tmp
+/cache

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,0 +1,7 @@
+[core]
+    remote = drive
+['remote "drive"']
+    url = gdrive://1xkVU9xGgNCMOAs2WOsdlSPxkBgc5YNeA
+    gdrive_acknowledge_abuse = true
+    gdrive_client_id = 600120103727-egn5jmkquf1ggv72i3781bcuhp7ponaa.apps.googleusercontent.com
+    gdrive_client_secret = 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

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,5 @@
+# Add patterns of files dvc should ignore, which could improve
+# the performance. Learn more at
+# https://dvc.org/doc/user-guide/dvcignore
+
+*.tsv

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-data/*.tsv
+data/*

--- a/data.dvc
+++ b/data.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: 85e55071ad40e85f7f2adfeec4021bbd.dir
+  size: 1191212400
+  nfiles: 1
+  hash: md5
+  path: data

--- a/data/dump.zip
+++ b/data/dump.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:75dfeb09fe6e11a9679c299aee21f25cdc983a081f0555792282d02d4c0273f7
-size 1191212400


### PR DESCRIPTION
this pr changes the data dump storage from Git LFS to [DVC](https://dvc.org/), so that we can store the data dumps on google drive