### PR TITLE
feat: add initial mp filtering ui

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -1,9 +1,9 @@
 // @ts-check
-import { defineConfig } from 'astro/config';
+import { defineConfig } from "astro/config";
 
 // https://astro.build/config
 export default defineConfig({
-  server: {
-    host: true
-  }
+    server: {
+        host: true,
+    },
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "major-motion",
       "version": "0.0.1",
       "dependencies": {
+        "@daviddarnes/live-filter": "^1.1.0",
         "astro": "^5.8.1",
         "kysely": "^0.28.2",
         "pg": "^8.16.0"
@@ -164,6 +165,12 @@
         "cross-fetch": "^3.0.4",
         "fontkit": "^2.0.2"
       }
+    },
+    "node_modules/@daviddarnes/live-filter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@daviddarnes/live-filter/-/live-filter-1.1.0.tgz",
+      "integrity": "sha512-XGf6B1TjXjafoBV+2CHQLVjQlmH7BjTtoMBCpiszNehEBQii+pQj2A9FkgFQLIGRy14oDCIhYD5l/iQCQosDcw==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.4.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "codegen": "kysely-codegen --out-file ./src/database.gen.d.ts"
   },
   "dependencies": {
+    "@daviddarnes/live-filter": "^1.1.0",
     "astro": "^5.8.1",
     "kysely": "^0.28.2",
     "pg": "^8.16.0"

--- a/frontend/src/components/MemberListItem.astro
+++ b/frontend/src/components/MemberListItem.astro
@@ -1,0 +1,54 @@
+---
+import { Image } from "astro:assets";
+import type { ImageMetadata } from "astro";
+import { encode } from "../utils";
+import Profile from "../icons/profile.svg";
+
+interface Props {
+    mp: {
+        full_name: string | null;
+        photo: string | null;
+        party_id: string | null;
+    };
+}
+
+const { mp } = Astro.props;
+const filename = mp.photo && `/src/assets/${mp.photo}`;
+const images = import.meta.glob<{ default: ImageMetadata }>(
+    "/src/assets/*.{jpeg,jpg,png,gif}"
+);
+---
+
+<article>
+    {
+        filename && images[filename] ? (
+            <Image
+                src={images[filename]()}
+                alt={mp.full_name}
+                width="100"
+                height="150"
+            />
+        ) : (
+            <Profile class="missing" />
+        )
+    }
+    <p>
+        <strong>{mp.full_name}</strong>
+        {mp.party_id}
+        <br />
+        <a href={`/edustaja/${encode(mp.full_name || "")}`}>open mp page</a>
+    </p>
+</article>
+
+<style>
+    article {
+        display: flex;
+        flex-direction: row;
+        gap: var(--pico-block-spacing-horizontal);
+    }
+    .missing {
+        height: 150px;
+        width: 100px;
+        background-color: #ccc;
+    }
+</style>

--- a/frontend/src/database.gen.d.ts
+++ b/frontend/src/database.gen.d.ts
@@ -5,29 +5,26 @@
 
 import type { ColumnType } from "kysely";
 
+export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S, I | undefined, U>
+  : ColumnType<T, T | undefined, T>;
+
 export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
 export type Vote = "absent" | "abstain" | "no" | "yes";
 
-export interface AgendaItems {
-  id: number;
-  time: Timestamp | null;
-  title: string | null;
-  url: string | null;
-}
-
 export interface Ballots {
-  agenda_item_id: number | null;
   id: number;
   minutes_url: string | null;
   results_url: string | null;
-  time: Timestamp | null;
+  session_item_title: string | null;
+  start_time: Timestamp | null;
   title: string | null;
 }
 
 export interface Interests {
   category: string | null;
-  id: number;
+  id: Generated<number>;
   interest: string | null;
   mp_id: number | null;
 }
@@ -38,20 +35,21 @@ export interface MembersOfParliament {
   first_name: string | null;
   full_name: string | null;
   id: number;
+  last_name: string | null;
   minister: boolean | null;
   occupation: string | null;
-  party: string | null;
   phone_number: string | null;
+  photo: string | null;
   place_of_birth: string | null;
   place_of_residence: string | null;
   year_of_birth: number | null;
 }
 
 export interface MpPartyMemberships {
-  end_time: Timestamp | null;
+  end_date: Timestamp | null;
   mp_id: number;
   party_id: string;
-  start_time: Timestamp;
+  start_date: Timestamp;
 }
 
 export interface Parties {
@@ -66,7 +64,6 @@ export interface Votes {
 }
 
 export interface DB {
-  agenda_items: AgendaItems;
   ballots: Ballots;
   interests: Interests;
   members_of_parliament: MembersOfParliament;

--- a/frontend/src/icons/profile.svg
+++ b/frontend/src/icons/profile.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-user"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -1,31 +1,68 @@
 ---
+// we disable this rule as our style declaration has automagically applied
+// styles from live-filter
+/* eslint-disable astro/no-unused-css-selector */
 import Layout from "../layouts/Layout.astro";
 
 import { db } from "../database";
-import { encode } from "../utils";
+import MemberListItem from "../components/MemberListItem.astro";
 
-const data = await db.selectFrom("members_of_parliament").selectAll().execute();
+const data = await db
+    .selectFrom("members_of_parliament")
+    .leftJoin(
+        "mp_party_memberships",
+        "members_of_parliament.id",
+        "mp_party_memberships.mp_id"
+    )
+    .select([
+        "members_of_parliament.id",
+        "members_of_parliament.full_name",
+        "members_of_parliament.photo",
+        "mp_party_memberships.party_id",
+    ])
+    .distinctOn("members_of_parliament.id")
+    .execute();
 ---
 
 <Layout>
     <main>
         <h1>Eduri</h1>
         <p>Tähän sit kontsaa</p>
-        <ul>
-            {
-                data.map((mp) => (
-                    <li>
-                        <p>
-                            <strong>{mp.full_name}</strong>
-                            <br />
-                            {mp.party}
-                            <a href={`/edustaja/${encode(mp.full_name || "")}`}>
-                                open mp page
-                            </a>
-                        </p>
-                    </li>
-                ))
-            }
-        </ul>
+
+        <live-filter case="insensitive">
+            <input
+                aria-controls="list"
+                aria-label="Hae kansanedustajista..."
+                placeholder="Hae kansanedustajista..."
+                type="search"
+            />
+            <ul aria-live="polite" id="list">
+                {
+                    data.map((mp) => (
+                        <li>
+                            <MemberListItem mp={mp} />
+                        </li>
+                    ))
+                }
+            </ul>
+        </live-filter>
     </main>
 </Layout>
+
+<script>
+    // as web components rely on DOM APIs, we need to lazily load this script
+    // only in client and not during rendering.
+    import "@daviddarnes/live-filter";
+</script>
+
+<style>
+    ul {
+        padding-inline-start: unset;
+    }
+    li {
+        list-style: none;
+    }
+    [data-live-filter-match="false"] {
+        display: none;
+    }
+</style>


### PR DESCRIPTION
run the ui with `cd frontend && npm run dev` and then open browser to `http://localhost:4321` as instructed in terminal